### PR TITLE
Fix failing test on some environments

### DIFF
--- a/src/clique_config.erl
+++ b/src/clique_config.erl
@@ -420,6 +420,9 @@ set_config_test_() ->
 -define(SET_TEST_SCHEMA_FILE, "test.schema").
 
 set_config_test_setup() ->
+    %% belt and braces, failing tests observed on ubuntu 16.04 fixed
+    %% by this addition TODO figure out why and better address
+    (catch set_config_test_teardown(ok)),
     Schema = <<"{mapping, \"test.config\", \"clique.config_test\", [{datatype, integer}]}.">>,
     {ok, Cwd} = file:get_cwd(),
 


### PR DESCRIPTION
On ubuntu 16.04 r16b02_basho10 clique_config test fails when trying to
create ets tables (they already exist!) The teardown _should_ have
removed them. Rather than a full rabbit hole excavation, I've added a
"belt-and-braces" run teardown before setup. This seems to work. I left
a comment in place about why the change, and hopefully one day we can
fix it properly.